### PR TITLE
Fix UDP timeout during DNS querying

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -40,7 +40,6 @@ IncludeCategories:
 IncludeIsMainRegex: '([-_](test|unittest))?$'
 IndentCaseLabels: true
 IndentWidth: 4
-InsertNewlineAtEOF: true
 MacroBlockBegin: ''
 MacroBlockEnd: ''
 MaxEmptyLinesToKeep: 1

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@
 
 # IDE
 .idea
+.cache/

--- a/include/resolver.hpp
+++ b/include/resolver.hpp
@@ -26,8 +26,8 @@ namespace kyrylokupin::asio::dns {
 
         template<qtype T>
         auto query(const std::string domain) -> asio::awaitable<std::vector<dns_answer<T>>> {
-            static constexpr auto timeout_seconds = 10;
-            static constexpr auto input_buffer_size = 1024;
+            static constexpr auto timeout_seconds = 2;
+            static constexpr auto input_buffer_size = 2048;
             static constexpr auto max_retry_count = 3;
             const auto query = create_query<T>(domain);
             auto buf = asio::streambuf{};
@@ -50,8 +50,8 @@ namespace kyrylokupin::asio::dns {
             } while (receive_ec != boost::system::errc::success and current_retry_count < max_retry_count);
             if (current_retry_count == max_retry_count and receive_ec != boost::system::errc::success) {
                 throw std::runtime_error(
-                        fmt::format("Timeout while waiting for UDP response, error code: {} error value: {}",
-                                    receive_ec.value(), receive_ec.message()));
+                        fmt::format("Timeout while waiting for UDP response, error code: {} error value: {} retries {}",
+                                    receive_ec.value(), receive_ec.message(), current_retry_count));
             }
 
             auto dns_response = kyrylokupin::asio::dns::dns_response<T>{};

--- a/include/resolver.hpp
+++ b/include/resolver.hpp
@@ -28,7 +28,7 @@ namespace kyrylokupin::asio::dns {
         auto query(const std::string domain) -> asio::awaitable<std::vector<dns_answer<T>>> {
             static constexpr auto timeout_seconds = 3;
             static constexpr auto input_buffer_size = 2048;
-            static constexpr auto max_retry_count = 3;
+            static constexpr auto max_retry_count = 10;
             const auto query = create_query<T>(domain);
             auto buf = asio::streambuf{};
             auto out = std::ostream{&buf};

--- a/include/resolver.hpp
+++ b/include/resolver.hpp
@@ -54,7 +54,9 @@ namespace kyrylokupin::asio::dns {
                 instream >> dns_response;
                 co_return dns_response.answers;
             } else {
-                throw std::runtime_error("Timeout waiting for UDP response");
+                throw std::runtime_error(
+                        fmt::format("Timeout while waiting for UDP response, error code: {} error value: {}",
+                                    receive_ec.value(), receive_ec.message()));
             }
         }
 

--- a/include/resolver.hpp
+++ b/include/resolver.hpp
@@ -33,13 +33,13 @@ namespace kyrylokupin::asio::dns {
             auto buf = asio::streambuf{};
             auto out = std::ostream{&buf};
             out << query;
-            co_await socket_.async_send(buffer(buf.data(), buf.size()), asio::use_awaitable);
 
             auto input = std::array<char, input_buffer_size>{};
             auto timer = asio::steady_timer{co_await asio::this_coro::executor};
             boost::system::error_code receive_ec;
             auto current_retry_count = 0;
             do {
+                co_await socket_.async_send(buffer(buf.data(), buf.size()), asio::use_awaitable);
                 ++current_retry_count;
                 timer.expires_after(std::chrono::seconds(timeout_seconds));
                 std::tie(std::ignore, receive_ec, std::ignore, std::ignore) =

--- a/include/resolver.hpp
+++ b/include/resolver.hpp
@@ -26,7 +26,7 @@ namespace kyrylokupin::asio::dns {
 
         template<qtype T>
         auto query(const std::string domain) -> asio::awaitable<std::vector<dns_answer<T>>> {
-            static constexpr auto timeout_seconds = 2;
+            static constexpr auto timeout_seconds = 3;
             static constexpr auto input_buffer_size = 2048;
             static constexpr auto max_retry_count = 3;
             const auto query = create_query<T>(domain);

--- a/include/resolver.hpp
+++ b/include/resolver.hpp
@@ -6,12 +6,9 @@
 #include "dns_response.hpp"
 #include "qtype.hpp"
 
-#include "boost/asio.hpp"
 #include "boost/asio/experimental/parallel_group.hpp"
 
-#include <random>
 #include <sstream>
-#include <typeinfo>
 
 #include <fmt/core.h>
 

--- a/include/resolver.hpp
+++ b/include/resolver.hpp
@@ -1,97 +1,124 @@
 #pragma once
 
+#include "boost/asio/use_awaitable.hpp"
 #include "dns_query.hpp"
 #include "dns_response.hpp"
 #include "qtype.hpp"
 
 #include "boost/asio.hpp"
+#include "boost/asio/experimental/parallel_group.hpp"
 
 #include <random>
 #include <sstream>
 
 namespace kyrylokupin::asio::dns {
-    namespace asio = boost::asio;
+namespace asio = boost::asio;
 
-    class resolver {
-    public:
-        explicit resolver(const asio::any_io_executor &executor) : socket_(executor) {}
+class resolver {
+public:
+  explicit resolver(const asio::any_io_executor &executor)
+      : socket_(executor) {}
 
-        auto connect(const std::string server) -> asio::awaitable<void> {
-            constexpr auto DNS_PORT = 53;
-            co_await socket_.async_connect({asio::ip::address::from_string(server), DNS_PORT}, asio::use_awaitable);
-        }
+  auto connect(const std::string server) -> asio::awaitable<void> {
+    constexpr auto DNS_PORT = 53;
+    co_await socket_.async_connect(
+        {asio::ip::address::from_string(server), DNS_PORT},
+        asio::use_awaitable);
+  }
 
-        template<qtype T>
-        auto query(const std::string domain) -> asio::awaitable<std::vector<dns_answer<T>>> {
-            const auto query = create_query<T>(domain);
-            auto buf = asio::streambuf{};
-            auto out = std::ostream{&buf};
-            out << query;
-            co_await socket_.async_send(buffer(buf.data(), buf.size()), asio::use_awaitable);
+  template <qtype T>
+  auto query(const std::string domain)
+      -> asio::awaitable<std::vector<dns_answer<T>>> {
+    static constexpr auto timeout_seconds = 5;
+    static constexpr auto INPUT_BUFFER_SIZE = 1024;
+    const auto query = create_query<T>(domain);
+    auto buf = asio::streambuf{};
+    auto out = std::ostream{&buf};
+    out << query;
+    co_await socket_.async_send(buffer(buf.data(), buf.size()),
+                                asio::use_awaitable);
 
-            auto input = std::array<char, 1024>{};
-            co_await socket_.async_receive(asio::buffer(input), asio::use_awaitable);
+    auto input = std::array<char, INPUT_BUFFER_SIZE>{};
+    auto timer = asio::steady_timer{co_await asio::this_coro::executor};
+    timer.expires_after(
+        std::chrono::seconds(timeout_seconds)); // Set timeout duration
 
-            auto dns_response = kyrylokupin::asio::dns::dns_response<T>{};
-            auto instream = std::istringstream{{input.begin(), input.end()}, std::ios::binary};
-            instream >> dns_response;
+    auto receive =
+        socket_.async_receive(asio::buffer(input), asio::use_awaitable);
+    auto wait = timer.async_wait(asio::use_awaitable);
 
-            co_return dns_response.answers;
-        }
+    auto [receive_result, receive_ec, wait_result, wait_ec] =
+        co_await asio::experimental::make_parallel_group(
+            [&](auto token) {
+              return socket_.async_receive(asio::buffer(input), token);
+            },
+            [&](auto token) { return timer.async_wait(token); })
+            .async_wait(boost::asio::experimental::wait_for_one(),
+                        asio::use_awaitable);
 
-    private:
-        static auto generate_id() -> std::uint16_t;
-
-        template<qtype T>
-        auto create_query(const std::string &name) {
-            return dns_query{.header =
-                                     {
-                                             .id = generate_id(),
-                                             .rd = 0x01,
-                                             .qdcount = 0x01,
-                                     },
-                             .question = {
-                                     .qname = name,
-                                     .type = T,
-                                     .cls = qclass::INET,
-                             }};
-        }
-
-        static auto reverse_qname(const std::string &name) -> std::string {
-            auto iss = std::istringstream{name};
-            auto segment = std::string{};
-            auto segments = std::vector<std::string>{};
-
-            while (std::getline(iss, segment, '.')) {
-                segments.push_back(segment);
-            }
-
-            std::reverse(segments.begin(), segments.end());
-
-            auto reversed_ip = std::string{};
-            for (const auto &seg: segments) {
-                reversed_ip += seg + '.';
-            }
-
-            return reversed_ip;
-        }
-
-        asio::ip::udp::socket socket_;
-    };
-
-    template<>
-    inline auto resolver::create_query<qtype::PTR>(const std::string &name) {
-        const auto qname = reverse_qname(name) + "in-addr.arpa";
-        return dns_query{.header =
-                                 {
-                                         .id = generate_id(),
-                                         .rd = 0x01,
-                                         .qdcount = 0x01,
-                                 },
-                         .question = {
-                                 .qname = qname,
-                                 .type = qtype::PTR,
-                                 .cls = qclass::INET,
-                         }};
+    if (receive_result[0] == 0) {
+      auto dns_response = kyrylokupin::asio::dns::dns_response<T>{};
+      auto instream =
+          std::istringstream{{input.begin(), input.end()}, std::ios::binary};
+      instream >> dns_response;
+      co_return dns_response.answers;
+    } else {
+      throw std::runtime_error("Timeout waiting for UDP response");
     }
-} // namespace KyryloKupin::asio::dns
+  }
+
+private:
+  static auto generate_id() -> std::uint16_t;
+
+  template <qtype T> auto create_query(const std::string &name) {
+    return dns_query{.header =
+                         {
+                             .id = generate_id(),
+                             .rd = 0x01,
+                             .qdcount = 0x01,
+                         },
+                     .question = {
+                         .qname = name,
+                         .type = T,
+                         .cls = qclass::INET,
+                     }};
+  }
+
+  static auto reverse_qname(const std::string &name) -> std::string {
+    auto iss = std::istringstream{name};
+    auto segment = std::string{};
+    auto segments = std::vector<std::string>{};
+
+    while (std::getline(iss, segment, '.')) {
+      segments.push_back(segment);
+    }
+
+    std::reverse(segments.begin(), segments.end());
+
+    auto reversed_ip = std::string{};
+    for (const auto &seg : segments) {
+      reversed_ip += seg + '.';
+    }
+
+    return reversed_ip;
+  }
+
+  asio::ip::udp::socket socket_;
+};
+
+template <>
+inline auto resolver::create_query<qtype::PTR>(const std::string &name) {
+  const auto qname = reverse_qname(name) + "in-addr.arpa";
+  return dns_query{.header =
+                       {
+                           .id = generate_id(),
+                           .rd = 0x01,
+                           .qdcount = 0x01,
+                       },
+                   .question = {
+                       .qname = qname,
+                       .type = qtype::PTR,
+                       .cls = qclass::INET,
+                   }};
+}
+} // namespace kyrylokupin::asio::dns

--- a/include/resolver.hpp
+++ b/include/resolver.hpp
@@ -48,7 +48,7 @@ namespace kyrylokupin::asio::dns {
                                 [&](auto token) { return timer.async_wait(token); })
                                 .async_wait(boost::asio::experimental::wait_for_one(), asio::use_awaitable);
             } while (receive_ec != boost::system::errc::success and current_retry_count < max_retry_count);
-            if (current_retry_count == max_retry_count) {
+            if (current_retry_count == max_retry_count and receive_ec != boost::system::errc::success) {
                 throw std::runtime_error(
                         fmt::format("Timeout while waiting for UDP response, error code: {} error value: {}",
                                     receive_ec.value(), receive_ec.message()));

--- a/include/resolver.hpp
+++ b/include/resolver.hpp
@@ -25,7 +25,7 @@ namespace kyrylokupin::asio::dns {
 
         template<qtype T>
         auto query(const std::string domain) -> asio::awaitable<std::vector<dns_answer<T>>> {
-            static constexpr auto timeout_seconds = 5;
+            static constexpr auto timeout_seconds = 10;
             static constexpr auto INPUT_BUFFER_SIZE = 1024;
             const auto query = create_query<T>(domain);
             auto buf = asio::streambuf{};

--- a/include/resolver.hpp
+++ b/include/resolver.hpp
@@ -1,16 +1,16 @@
 #pragma once
 
-#include "boost/asio/use_awaitable.hpp"
-#include "boost/system/detail/errc.hpp"
 #include "dns_query.hpp"
 #include "dns_response.hpp"
 #include "qtype.hpp"
 
 #include "boost/asio/experimental/parallel_group.hpp"
-
-#include <sstream>
+#include "boost/asio/use_awaitable.hpp"
+#include "boost/system/detail/errc.hpp"
 
 #include <fmt/core.h>
+
+#include <sstream>
 
 namespace kyrylokupin::asio::dns {
     namespace asio = boost::asio;

--- a/include/resolver.hpp
+++ b/include/resolver.hpp
@@ -12,113 +12,103 @@
 #include <sstream>
 
 namespace kyrylokupin::asio::dns {
-namespace asio = boost::asio;
+    namespace asio = boost::asio;
 
-class resolver {
-public:
-  explicit resolver(const asio::any_io_executor &executor)
-      : socket_(executor) {}
+    class resolver {
+    public:
+        explicit resolver(const asio::any_io_executor &executor) : socket_(executor) {}
 
-  auto connect(const std::string server) -> asio::awaitable<void> {
-    constexpr auto DNS_PORT = 53;
-    co_await socket_.async_connect(
-        {asio::ip::address::from_string(server), DNS_PORT},
-        asio::use_awaitable);
-  }
+        auto connect(const std::string server) -> asio::awaitable<void> {
+            constexpr auto DNS_PORT = 53;
+            co_await socket_.async_connect({asio::ip::address::from_string(server), DNS_PORT}, asio::use_awaitable);
+        }
 
-  template <qtype T>
-  auto query(const std::string domain)
-      -> asio::awaitable<std::vector<dns_answer<T>>> {
-    static constexpr auto timeout_seconds = 5;
-    static constexpr auto INPUT_BUFFER_SIZE = 1024;
-    const auto query = create_query<T>(domain);
-    auto buf = asio::streambuf{};
-    auto out = std::ostream{&buf};
-    out << query;
-    co_await socket_.async_send(buffer(buf.data(), buf.size()),
-                                asio::use_awaitable);
+        template<qtype T>
+        auto query(const std::string domain) -> asio::awaitable<std::vector<dns_answer<T>>> {
+            static constexpr auto timeout_seconds = 5;
+            static constexpr auto INPUT_BUFFER_SIZE = 1024;
+            const auto query = create_query<T>(domain);
+            auto buf = asio::streambuf{};
+            auto out = std::ostream{&buf};
+            out << query;
+            co_await socket_.async_send(buffer(buf.data(), buf.size()), asio::use_awaitable);
 
-    auto input = std::array<char, INPUT_BUFFER_SIZE>{};
-    auto timer = asio::steady_timer{co_await asio::this_coro::executor};
-    timer.expires_after(
-        std::chrono::seconds(timeout_seconds)); // Set timeout duration
+            auto input = std::array<char, INPUT_BUFFER_SIZE>{};
+            auto timer = asio::steady_timer{co_await asio::this_coro::executor};
+            timer.expires_after(std::chrono::seconds(timeout_seconds)); // Set timeout duration
 
-    auto receive =
-        socket_.async_receive(asio::buffer(input), asio::use_awaitable);
-    auto wait = timer.async_wait(asio::use_awaitable);
+            auto receive = socket_.async_receive(asio::buffer(input), asio::use_awaitable);
+            auto wait = timer.async_wait(asio::use_awaitable);
 
-    auto [receive_result, receive_ec, wait_result, wait_ec] =
-        co_await asio::experimental::make_parallel_group(
-            [&](auto token) {
-              return socket_.async_receive(asio::buffer(input), token);
-            },
-            [&](auto token) { return timer.async_wait(token); })
-            .async_wait(boost::asio::experimental::wait_for_one(),
-                        asio::use_awaitable);
+            auto [receive_result, receive_ec, wait_result, wait_ec] =
+                    co_await asio::experimental::make_parallel_group(
+                            [&](auto token) { return socket_.async_receive(asio::buffer(input), token); },
+                            [&](auto token) { return timer.async_wait(token); })
+                            .async_wait(boost::asio::experimental::wait_for_one(), asio::use_awaitable);
 
-    if (receive_result[0] == 0) {
-      auto dns_response = kyrylokupin::asio::dns::dns_response<T>{};
-      auto instream =
-          std::istringstream{{input.begin(), input.end()}, std::ios::binary};
-      instream >> dns_response;
-      co_return dns_response.answers;
-    } else {
-      throw std::runtime_error("Timeout waiting for UDP response");
+            if (receive_result[0] == 0) {
+                auto dns_response = kyrylokupin::asio::dns::dns_response<T>{};
+                auto instream = std::istringstream{{input.begin(), input.end()}, std::ios::binary};
+                instream >> dns_response;
+                co_return dns_response.answers;
+            } else {
+                throw std::runtime_error("Timeout waiting for UDP response");
+            }
+        }
+
+    private:
+        static auto generate_id() -> std::uint16_t;
+
+        template<qtype T>
+        auto create_query(const std::string &name) {
+            return dns_query{.header =
+                                     {
+                                             .id = generate_id(),
+                                             .rd = 0x01,
+                                             .qdcount = 0x01,
+                                     },
+                             .question = {
+                                     .qname = name,
+                                     .type = T,
+                                     .cls = qclass::INET,
+                             }};
+        }
+
+        static auto reverse_qname(const std::string &name) -> std::string {
+            auto iss = std::istringstream{name};
+            auto segment = std::string{};
+            auto segments = std::vector<std::string>{};
+
+            while (std::getline(iss, segment, '.')) {
+                segments.push_back(segment);
+            }
+
+            std::reverse(segments.begin(), segments.end());
+
+            auto reversed_ip = std::string{};
+            for (const auto &seg: segments) {
+                reversed_ip += seg + '.';
+            }
+
+            return reversed_ip;
+        }
+
+        asio::ip::udp::socket socket_;
+    };
+
+    template<>
+    inline auto resolver::create_query<qtype::PTR>(const std::string &name) {
+        const auto qname = reverse_qname(name) + "in-addr.arpa";
+        return dns_query{.header =
+                                 {
+                                         .id = generate_id(),
+                                         .rd = 0x01,
+                                         .qdcount = 0x01,
+                                 },
+                         .question = {
+                                 .qname = qname,
+                                 .type = qtype::PTR,
+                                 .cls = qclass::INET,
+                         }};
     }
-  }
-
-private:
-  static auto generate_id() -> std::uint16_t;
-
-  template <qtype T> auto create_query(const std::string &name) {
-    return dns_query{.header =
-                         {
-                             .id = generate_id(),
-                             .rd = 0x01,
-                             .qdcount = 0x01,
-                         },
-                     .question = {
-                         .qname = name,
-                         .type = T,
-                         .cls = qclass::INET,
-                     }};
-  }
-
-  static auto reverse_qname(const std::string &name) -> std::string {
-    auto iss = std::istringstream{name};
-    auto segment = std::string{};
-    auto segments = std::vector<std::string>{};
-
-    while (std::getline(iss, segment, '.')) {
-      segments.push_back(segment);
-    }
-
-    std::reverse(segments.begin(), segments.end());
-
-    auto reversed_ip = std::string{};
-    for (const auto &seg : segments) {
-      reversed_ip += seg + '.';
-    }
-
-    return reversed_ip;
-  }
-
-  asio::ip::udp::socket socket_;
-};
-
-template <>
-inline auto resolver::create_query<qtype::PTR>(const std::string &name) {
-  const auto qname = reverse_qname(name) + "in-addr.arpa";
-  return dns_query{.header =
-                       {
-                           .id = generate_id(),
-                           .rd = 0x01,
-                           .qdcount = 0x01,
-                       },
-                   .question = {
-                       .qname = qname,
-                       .type = qtype::PTR,
-                       .cls = qclass::INET,
-                   }};
-}
 } // namespace kyrylokupin::asio::dns

--- a/scripts/build-project.sh
+++ b/scripts/build-project.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cmake --build build --parallel 4

--- a/scripts/configure-buildtree.sh
+++ b/scripts/configure-buildtree.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cmake -S all -B build

--- a/scripts/run-ab-benchmark.sh
+++ b/scripts/run-ab-benchmark.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+ab -n 10000 -c 1000 "http://localhost:8080/resolve?gmail.com&MX"

--- a/source/resolver.cpp
+++ b/source/resolver.cpp
@@ -1,5 +1,7 @@
 #include "resolver.hpp"
 
+#include <random>
+
 using namespace kyrylokupin::asio::dns;
 
 auto resolver::generate_id() -> decltype(generate_id()) {

--- a/standalone/source/example.cpp
+++ b/standalone/source/example.cpp
@@ -9,61 +9,67 @@ namespace http = beast::http;
 namespace asio = boost::asio;
 namespace dns = kyrylokupin::asio::dns;
 
-auto handle_session(asio::ip::tcp::socket socket, std::shared_ptr<dns::resolver> resolver)
-        -> asio::awaitable<void> {
-    try {
-        auto buffer = beast::flat_buffer{};
-        auto request = http::request<http::string_body>{};
-        co_await http::async_read(socket, buffer, request, asio::use_awaitable);
+auto handle_session(asio::ip::tcp::socket socket,
+                    std::shared_ptr<dns::resolver> resolver)
+    -> asio::awaitable<void> {
+  try {
+    auto buffer = beast::flat_buffer{};
+    auto request = http::request<http::string_body>{};
+    co_await http::async_read(socket, buffer, request, asio::use_awaitable);
 
-        if (request.method() == http::verb::get and request.target().starts_with("/resolve?")) {
-            const auto params = request.target().substr(9);
-            if (const auto pos = params.find("&"); pos != std::string::npos) {
-                const auto domain = params.substr(0, pos);
-                const auto query_type = params.substr(pos + 1);
+    if (request.method() == http::verb::get and
+        request.target().starts_with("/resolve?")) {
+      const auto params = request.target().substr(9);
+      if (const auto pos = params.find("&"); pos != std::string::npos) {
+        const auto domain = params.substr(0, pos);
+        const auto query_type = params.substr(pos + 1);
 
-                auto result = co_await resolver->query<dns::qtype::MX>(domain);
+        auto result = co_await resolver->query<dns::qtype::MX>(domain);
 
-                auto response = http::response<http::string_body>{http::status::ok, request.version()};
-                response.set(http::field::server, BOOST_BEAST_VERSION_STRING);
-                response.set(http::field::content_type, "text/plain");
+        auto response = http::response<http::string_body>{http::status::ok,
+                                                          request.version()};
+        response.set(http::field::server, BOOST_BEAST_VERSION_STRING);
+        response.set(http::field::content_type, "text/plain");
 
-                auto output = std::ostringstream{};
-                for (const auto &answer: result) {
-                    auto [preference, domain] = answer.rdata;
-                    output << "Preference: " << preference << ", ";
-                    output << "MX: " << domain << ";\n";
-                }
-
-                response.body() = output.str();
-                response.prepare_payload();
-                co_await http::async_write(socket, response, asio::use_awaitable);
-            }
+        auto output = std::ostringstream{};
+        for (const auto &answer : result) {
+          auto [preference, domain] = answer.rdata;
+          output << "Preference: " << preference << ", ";
+          output << "MX: " << domain << ";\n";
         }
 
-        socket.shutdown(asio::ip::tcp::socket::shutdown_send);
-    } catch (std::exception &e) {
-        std::cerr << "Error: " << e.what() << '\n';
+        response.body() = output.str();
+        response.prepare_payload();
+        co_await http::async_write(socket, response, asio::use_awaitable);
+      }
     }
+
+    socket.shutdown(asio::ip::tcp::socket::shutdown_send);
+  } catch (std::exception &e) {
+    std::cerr << "Error: " << e.what() << '\n';
+  }
 }
 
 auto listener(asio::ip::tcp::acceptor acceptor) -> asio::awaitable<void> {
-    const auto resolver = std::make_shared<dns::resolver>(acceptor.get_executor());
-    co_await resolver->connect("1.1.1.1");
+  const auto resolver =
+      std::make_shared<dns::resolver>(acceptor.get_executor());
+  co_await resolver->connect("1.1.1.1");
 
-    for (;;) {
-        auto socket = co_await acceptor.async_accept(asio::use_awaitable);
-        co_spawn(acceptor.get_executor(), handle_session(std::move(socket), resolver), asio::detached);
-    }
+  for (;;) {
+    auto socket = co_await acceptor.async_accept(asio::use_awaitable);
+    co_spawn(acceptor.get_executor(),
+             handle_session(std::move(socket), resolver), asio::detached);
+  }
 }
 
 auto main() -> int {
-    constexpr auto PORT = 8080;
+  constexpr auto PORT = 8080;
 
-    auto io_context = asio::io_context{};
-    auto acceptor = asio::ip::tcp::acceptor{io_context, {asio::ip::tcp::v4(), PORT}};
-    co_spawn(io_context, listener(std::move(acceptor)), asio::detached);
-    io_context.run();
+  auto io_context = asio::io_context{};
+  auto acceptor =
+      asio::ip::tcp::acceptor{io_context, {asio::ip::tcp::v4(), PORT}};
+  co_spawn(io_context, listener(std::move(acceptor)), asio::detached);
+  io_context.run();
 
-    return {};
+  return {};
 }

--- a/standalone/source/example.cpp
+++ b/standalone/source/example.cpp
@@ -9,67 +9,60 @@ namespace http = beast::http;
 namespace asio = boost::asio;
 namespace dns = kyrylokupin::asio::dns;
 
-auto handle_session(asio::ip::tcp::socket socket,
-                    std::shared_ptr<dns::resolver> resolver)
-    -> asio::awaitable<void> {
-  try {
-    auto buffer = beast::flat_buffer{};
-    auto request = http::request<http::string_body>{};
-    co_await http::async_read(socket, buffer, request, asio::use_awaitable);
+auto handle_session(asio::ip::tcp::socket socket, std::shared_ptr<dns::resolver> resolver) -> asio::awaitable<void> {
+    try {
+        auto buffer = beast::flat_buffer{};
+        auto request = http::request<http::string_body>{};
+        co_await http::async_read(socket, buffer, request, asio::use_awaitable);
 
-    if (request.method() == http::verb::get and
-        request.target().starts_with("/resolve?")) {
-      const auto params = request.target().substr(9);
-      if (const auto pos = params.find("&"); pos != std::string::npos) {
-        const auto domain = params.substr(0, pos);
-        const auto query_type = params.substr(pos + 1);
+        if (request.method() == http::verb::get and request.target().starts_with("/resolve?")) {
+            const auto params = request.target().substr(9);
+            if (const auto pos = params.find("&"); pos != std::string::npos) {
+                const auto domain = params.substr(0, pos);
+                const auto query_type = params.substr(pos + 1);
 
-        auto result = co_await resolver->query<dns::qtype::MX>(domain);
+                auto result = co_await resolver->query<dns::qtype::MX>(domain);
 
-        auto response = http::response<http::string_body>{http::status::ok,
-                                                          request.version()};
-        response.set(http::field::server, BOOST_BEAST_VERSION_STRING);
-        response.set(http::field::content_type, "text/plain");
+                auto response = http::response<http::string_body>{http::status::ok, request.version()};
+                response.set(http::field::server, BOOST_BEAST_VERSION_STRING);
+                response.set(http::field::content_type, "text/plain");
 
-        auto output = std::ostringstream{};
-        for (const auto &answer : result) {
-          auto [preference, domain] = answer.rdata;
-          output << "Preference: " << preference << ", ";
-          output << "MX: " << domain << ";\n";
+                auto output = std::ostringstream{};
+                for (const auto &answer: result) {
+                    auto [preference, domain] = answer.rdata;
+                    output << "Preference: " << preference << ", ";
+                    output << "MX: " << domain << ";\n";
+                }
+
+                response.body() = output.str();
+                response.prepare_payload();
+                co_await http::async_write(socket, response, asio::use_awaitable);
+            }
         }
 
-        response.body() = output.str();
-        response.prepare_payload();
-        co_await http::async_write(socket, response, asio::use_awaitable);
-      }
+        socket.shutdown(asio::ip::tcp::socket::shutdown_send);
+    } catch (std::exception &e) {
+        std::cerr << "Error: " << e.what() << '\n';
     }
-
-    socket.shutdown(asio::ip::tcp::socket::shutdown_send);
-  } catch (std::exception &e) {
-    std::cerr << "Error: " << e.what() << '\n';
-  }
 }
 
 auto listener(asio::ip::tcp::acceptor acceptor) -> asio::awaitable<void> {
-  const auto resolver =
-      std::make_shared<dns::resolver>(acceptor.get_executor());
-  co_await resolver->connect("1.1.1.1");
+    const auto resolver = std::make_shared<dns::resolver>(acceptor.get_executor());
+    co_await resolver->connect("1.1.1.1");
 
-  for (;;) {
-    auto socket = co_await acceptor.async_accept(asio::use_awaitable);
-    co_spawn(acceptor.get_executor(),
-             handle_session(std::move(socket), resolver), asio::detached);
-  }
+    for (;;) {
+        auto socket = co_await acceptor.async_accept(asio::use_awaitable);
+        co_spawn(acceptor.get_executor(), handle_session(std::move(socket), resolver), asio::detached);
+    }
 }
 
 auto main() -> int {
-  constexpr auto PORT = 8080;
+    constexpr auto PORT = 8080;
 
-  auto io_context = asio::io_context{};
-  auto acceptor =
-      asio::ip::tcp::acceptor{io_context, {asio::ip::tcp::v4(), PORT}};
-  co_spawn(io_context, listener(std::move(acceptor)), asio::detached);
-  io_context.run();
+    auto io_context = asio::io_context{};
+    auto acceptor = asio::ip::tcp::acceptor{io_context, {asio::ip::tcp::v4(), PORT}};
+    co_spawn(io_context, listener(std::move(acceptor)), asio::detached);
+    io_context.run();
 
-  return {};
+    return {};
 }

--- a/test/source/resolver.cpp
+++ b/test/source/resolver.cpp
@@ -25,10 +25,12 @@ protected:
     };
 };
 
+/*
 TEST_F(resolver_test, a) {
-    co_spawn(context_, query_test<qtype::A>({"tuposoft.com", 1, {"217.160.29.228"}}), detached);
+    co_spawn(context_, query_test<qtype::A>({"tuposoft.com", 2, {"172.67.216.64"}}), detached);
     context_.run();
 }
+*/
 
 TEST_F(resolver_test, mx) {
     constexpr auto PREFERENCE = 10;

--- a/test/source/resolver.cpp
+++ b/test/source/resolver.cpp
@@ -32,11 +32,13 @@ TEST_F(resolver_test, a) {
 }
 */
 
+/*
 TEST_F(resolver_test, mx) {
     constexpr auto PREFERENCE = 10;
     co_spawn(context_, query_test<qtype::MX>({"tuposoft.com", 1, {{PREFERENCE, "mail.tuposoft.com"}}}), detached);
     context_.run();
 }
+*/
 
 TEST_F(resolver_test, ptr) {
     co_spawn(context_, query_test<qtype::PTR>({"1.1.1.1", 1, {"one.one.one.one"}}), detached);

--- a/test/source/resolver.cpp
+++ b/test/source/resolver.cpp
@@ -18,9 +18,10 @@ protected:
         const auto result = co_await resolv.query<T>(name);
         EXPECT_EQ(result.size(), size);
         for (int i = 0; i < result.size(); ++i) {
-            EXPECT_EQ(result[i].rdata, expected[i]);
+            auto found_it = std::find(expected.begin(), expected.end(), result[i].rdata);
+            EXPECT_NE(found_it, expected.end());
         }
-    };
+    }
 };
 
 TEST_F(resolver_test, a) {

--- a/test/source/resolver.cpp
+++ b/test/source/resolver.cpp
@@ -1,7 +1,5 @@
 #include "resolver.hpp"
 
-#include "boost/asio.hpp"
-#include "boost/enable_shared_from_this.hpp"
 #include "gtest/gtest.h"
 
 using namespace kyrylokupin::asio::dns;
@@ -25,20 +23,25 @@ protected:
     };
 };
 
-/*
 TEST_F(resolver_test, a) {
-    co_spawn(context_, query_test<qtype::A>({"tuposoft.com", 2, {"172.67.216.64"}}), detached);
+    co_spawn(context_, query_test<qtype::A>({"example.com", 1, {"93.184.215.14"}}), detached);
     context_.run();
 }
-*/
 
-/*
 TEST_F(resolver_test, mx) {
-    constexpr auto PREFERENCE = 10;
-    co_spawn(context_, query_test<qtype::MX>({"tuposoft.com", 1, {{PREFERENCE, "mail.tuposoft.com"}}}), detached);
+    co_spawn(context_,
+             query_test<qtype::MX>({"gmail.com",
+                                    5,
+                                    {
+                                            {20, "alt2.gmail-smtp-in.l.google.com"},
+                                            {30, "alt3.gmail-smtp-in.l.google.com"},
+                                            {40, "alt4.gmail-smtp-in.l.google.com"},
+                                            {5, "gmail-smtp-in.l.google.com"},
+                                            {10, "alt1.gmail-smtp-in.l.google.com"},
+                                    }}),
+             detached);
     context_.run();
 }
-*/
 
 TEST_F(resolver_test, ptr) {
     co_spawn(context_, query_test<qtype::PTR>({"1.1.1.1", 1, {"one.one.one.one"}}), detached);


### PR DESCRIPTION
Fix not receiving data from UDP socket by adding an asynchronous timeout.
Will add mocks in separate PR.